### PR TITLE
Implement delete of object

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ my $secret-access-key = 'passw0rd';
 my $access-key-id = 'password1';
 my $region = 'us-east-1';
 
-my \s3 = S3.new(:secret-access-key, :$access-key-id, :$:region);
+my \s3 = S3.new(:$secret-access-key, :$access-key-id, :$region);
 
 s3.put:
    content => "Hello, world!!",

--- a/t/04-live.t
+++ b/t/04-live.t
@@ -3,7 +3,7 @@
 use lib 'lib';
 use WebService::AWS::S3;
 use Test;
-plan 14;
+plan 16;
 
 unless %*ENV<AWS_TEST_BUCKET> && %*ENV<AWS_TEST_PREFIX> {
   note "set AWS_TEST_BUCKET and AWS_TEST_PREFIX to run live tests";
@@ -52,5 +52,8 @@ ok $s3.put(:$content,:$url), "put plaintext";
 sleep 1;
 my $got = $s3.get($url);
 is $content, $got, "roundtrip";
+ok $s3.delete($url), "delete";
 
+$objects = $s3.list-objects(:$bucket, :$prefix);
 
+ok !$objects.objects.grep( *.url eq $url ), "and the object got deleted";


### PR DESCRIPTION
First up, thanks for the module.  I didn't know I needed it until last week and was delighted to find it just worked :1st_place_medal: 

This adds the 'delete' operation on an object, and a "live" test.
The new tests passes against my test S3 bucket and have also visually
examined the s3 dashboard while doing a 'put' and then a 'delete'.